### PR TITLE
Fix style compilation

### DIFF
--- a/etc/build/build.xml
+++ b/etc/build/build.xml
@@ -54,8 +54,8 @@
 		
 		<delete file="Graph-Stylesheet.js"/>
 		<echo file="Graph-Stylesheet.js">Graph.prototype.defaultThemes[Graph.prototype.defaultThemeName] = mxUtils.parseXml('</echo>
-		<concat destfile="Graph-Stylesheet.js" fixlastline="no" append="yes">
-			<file name=".tmp1.xml" />
+		<concat destfile="Graph-Stylesheet.js" fixlastline="no" append="true">
+			<file name="${basedir}/.tmp1.xml" />
     	</concat>
 		<echo file="Graph-Stylesheet.js" append="true">').documentElement;</echo>
 


### PR DESCRIPTION
Fix for the issue #17
At least ant 1.9.2 and 1.9.3 ignores append="yes" and accepts only "true", so the file being appended is just skipped without this fix.
