### PR TITLE
Use Oxford Comma in Supported Browsers Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ The full packaged .war of the client and servlets is built when the project is t
 
 Supported Browsers
 ------------------
-draw.io supports IE 11, Chrome 32+, Firefox 38+, Safari 7.1.x, 8.0.x, 9.1.x and 10.0.x, Opera 20+, Native Android browser 5.1.x+, the default browser in the current and previous major iOS versions (e.g. 10.x and 9.x) and Edge 23+.
+draw.io supports IE 11, Chrome 32+, Firefox 38+, Safari 7.1.x, 8.0.x, 9.1.x and 10.0.x, Opera 20+, Native Android browser 5.1.x+, the default browser in the current and previous major iOS versions (e.g. 10.x and 9.x), and Edge 23+.


### PR DESCRIPTION
Updated ReadMe to use the Oxford comma in the supported browsers section of the document.