### PR TITLE
Broken link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/jgraph/drawio.png?branch=master)](https://travis-ci.org/jgraph/draw.io)
+[![Build Status](https://travis-ci.org/jgraph/drawio.svg?branch=master)](https://travis-ci.org/jgraph/drawio)
 
 About
 -----


### PR DESCRIPTION
Hello!

Replaced the current build link with the one provided by [Travis CI](https://travis-ci.org/jgraph/drawio), if you click on the badge there.