### PR TITLE
Use relative path for templates

### DIFF
--- a/war/js/diagramly/Init.js
+++ b/war/js/diagramly/Init.js
@@ -19,7 +19,7 @@ window.SHAPES_PATH = window.SHAPES_PATH || 'shapes';
 window.GRAPH_IMAGE_PATH = window.GRAPH_IMAGE_PATH || 'img';
 window.ICONSEARCH_PATH = window.ICONSEARCH_PATH || ((navigator.userAgent.indexOf('MSIE') >= 0 ||
 	urlParams['dev']) && window.location.protocol != 'file:' ? 'iconSearch' : 'https://www.draw.io/iconSearch');
-window.TEMPLATE_PATH = window.TEMPLATE_PATH || '/templates';
+window.TEMPLATE_PATH = window.TEMPLATE_PATH || 'templates';
 
 // Directory for i18 files and basename for main i18n file
 window.RESOURCES_PATH = window.RESOURCES_PATH || 'resources';


### PR DESCRIPTION
Most of the site uses relative paths so hosting somewhere other than the root works fine.  Templates is one exception which results in no templates being available if you host at a "subdirectory" ex. https://example.com/drawio.

This changes the templates request to be relative.

I followed the instructions from the wiki and hosted the war folder locally (used python) and found the application still worked and resolved templates after this change when hosting at the root.