### PR TITLE
Adds basic command line support and fixes a small bug saving documents.

### DIFF
--- a/war/js/diagramly/ElectronApp.js
+++ b/war/js/diagramly/ElectronApp.js
@@ -701,7 +701,7 @@ FeedbackDialog.feedbackUrl = 'https://log.draw.io/email';
 				}), mxUtils.bind(this, function(resp)
 				{
 					this.editor.setStatus('');
-					this.handleError(resp, (resp != null) ? mxResources.get('errorSavingFile') : null);
+					this.handleError(resp, (resp === undefined || resp === null) ? mxResources.get('errorSavingFile') : null);
 				}));
 			}
 			else
@@ -713,7 +713,7 @@ FeedbackDialog.feedbackUrl = 'https://log.draw.io/email';
 				}), mxUtils.bind(this, function(resp)
 				{
 					this.editor.setStatus('');
-					this.handleError(resp, (resp != null) ? mxResources.get('errorSavingFile') : null);
+					this.handleError(resp, (resp === undefined || resp === null) ? mxResources.get('errorSavingFile') : null);
 				}));
 			}
 		}

--- a/war/js/diagramly/ElectronApp.js
+++ b/war/js/diagramly/ElectronApp.js
@@ -346,6 +346,79 @@ FeedbackDialog.feedbackUrl = 'https://log.draw.io/email';
 		});
 	}
 
+	App.prototype.load = function()
+	{
+		const {ipcRenderer} = require('electron');
+		
+		ipcRenderer.on('args-obj', (event, argsObj) =>
+		{
+			this.loadArgs(argsObj)
+		})
+	}
+	
+	App.prototype.loadArgs = function(argsObj)
+	{
+		var paths = argsObj.args;
+		
+		// If a file is passed 
+		if (paths !== undefined && paths[0] != null)
+		{
+			var path = paths[0];
+			
+			var success = mxUtils.bind(this, function(fileEntry, data)
+			{
+				var file = new LocalFile(this, data, '');
+				file.fileObject = fileEntry;
+				this.fileLoaded(file);
+				
+				this.start();
+			});
+			
+			var error = mxUtils.bind(this, function(e)
+			{
+				// If file not exists, but there is the "create-if-not-exists" flag 
+				if (e.code === 'ENOENT' && argsObj.createIfNotExists != null) {
+					var title = path.replace(/^.*[\\\/]/, '');
+					var data = this.emptyDiagramXml;
+					var file = new LocalFile(this, data, title, null);
+					
+					file.fileObject = new Object();
+					file.fileObject.path = path;
+					file.fileObject.name = title;
+					file.fileObject.type = 'utf-8';
+					this.fileCreated(file, null, null, null);					
+					this.saveFile();
+					
+					this.start();
+				}
+				else
+				{
+					this.start();
+					this.handleError(e);
+				}
+				
+			});
+			
+			// Tries to open the file
+			this.readGraphFile(success, error, path);
+		}
+		// If no file is passed, but there is the "create-if-not-exists" flag
+		else if (argsObj.createIfNotExists != null)
+		{
+			var title = 'Untitled document';
+			var data = this.emptyDiagramXml;
+			var file = new LocalFile(this, data, title, null);
+			this.fileCreated(file, null, null, null);
+			
+			this.start();
+		}
+		// If no args are passed 
+		else
+		{
+			this.start();
+		}		
+	}
+
 	// Uses local picker
 	App.prototype.pickFile = function()
 	{
@@ -405,35 +478,39 @@ FeedbackDialog.feedbackUrl = 'https://log.draw.io/email';
 	           
         if (paths !== undefined && paths[0] != null)
         {
-        	var fs = require('fs');
-        	var path = paths[0];
-        	var index = path.lastIndexOf('.png');
-        	var isPng = index > -1 && index == path.length - 4;
-        	var encoding = isPng ? 'base64' : 'utf-8'
-
-        	fs.readFile(path, encoding, mxUtils.bind(this, function (e, data)
-        	{
-        		if (e)
-        		{
-        			this.handleError(e);
-        		}
-        		else
-        		{
-        			if (isPng)
-        			{
-        				// Detecting png by extension. Would need https://github.com/mscdex/mmmagic
-        				// to do it by inspection
-        				data = this.extractGraphModelFromPng(data, true);
-        			}
-
-        			var fileEntry = new Object();
-        			fileEntry.path = path;
-        			fileEntry.name = path.replace(/^.*[\\\/]/, '');
-        			fileEntry.type = encoding;
-        			fn(fileEntry, data);
-        		}
-        	}));
+						this.readGraphFile(fn, this.handleError.bind(this), paths[0]);
         }
+	};
+
+	App.prototype.readGraphFile = function(fn, fnErr, path)
+	{
+		var fs = require('fs');
+		var index = path.lastIndexOf('.png');
+		var isPng = index > -1 && index == path.length - 4;
+		var encoding = isPng ? 'base64' : 'utf-8'
+
+		fs.readFile(path, encoding, mxUtils.bind(this, function (e, data)
+		{
+			if (e)
+			{
+				fnErr(e);
+			}
+			else
+			{
+				if (isPng)
+				{
+					// Detecting png by extension. Would need https://github.com/mscdex/mmmagic
+					// to do it by inspection
+					data = this.extractGraphModelFromPng(data, true);
+				}
+
+				var fileEntry = new Object();
+				fileEntry.path = path;
+				fileEntry.name = path.replace(/^.*[\\\/]/, '');
+				fileEntry.type = encoding;
+				fn(fileEntry, data);
+			}
+		}));
 	};
 
 	// Disables temp files in Electron

--- a/war/package.json
+++ b/war/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/jgraph/draw.io",
   "dependencies": {
+    "commander": "^2.12.2",
     "electron-log": "^2.2.7",
     "electron-updater": "^2.8.7"
   },


### PR DESCRIPTION
The proposed arguments are:
```
draw.io
draw.io test1.xml

draw.io -c
draw.io -c test1.xml
draw.io -h
draw.io -V

# (Extended version)
draw.io --create-if-not-exists
draw.io --create-if-not-exists test1.xml
draw.io --help
draw.io --version
```

This should resolve jgraph/drawio-desktop#4
