### PR TITLE
ImageDialog obeys the resize confirmation

### DIFF
--- a/src/main/webapp/js/diagramly/Dialogs.js
+++ b/src/main/webapp/js/diagramly/Dialogs.js
@@ -3921,7 +3921,7 @@ var ImageDialog = function(editorUi, title, initialValue, fn, ignoreExisting, co
 	inner.appendChild(cross);
 	div.appendChild(inner);
 
-	var insertImage = function(newValue, w, h)
+	var insertImage = function(newValue, w, h, resize)
 	{
 		var dataUri = newValue.substring(0, 5) == 'data:';
 		
@@ -3935,7 +3935,7 @@ var ImageDialog = function(editorUi, title, initialValue, fn, ignoreExisting, co
 				{
 					editorUi.spinner.stop();
 					editorUi.hideDialog();
-					var s = (w != null && h != null) ? Math.max(w / img.width, h / img.height) :
+					var s = resize === false ? 1 : (w != null && h != null) ? Math.max(w / img.width, h / img.height) :
 						Math.min(1, Math.min(maxSize / img.width, maxSize / img.height));
 					
 					// Handles special case of data URI which needs to be rewritten
@@ -3970,7 +3970,7 @@ var ImageDialog = function(editorUi, title, initialValue, fn, ignoreExisting, co
 		}
 	};
 	
-	var apply = function(newValue)
+	var apply = function(newValue, resize)
 	{
 		if (newValue != null)
 		{
@@ -3979,11 +3979,11 @@ var ImageDialog = function(editorUi, title, initialValue, fn, ignoreExisting, co
 			// Reuses width and height of existing cell
 			if (geo != null)
 			{
-				insertImage(newValue, geo.width, geo.height);
+				insertImage(newValue, geo.width, geo.height, resize);
 			}
 			else
 			{
-				insertImage(newValue);
+				insertImage(newValue, null, null, resize);
 			}
 		}
 		else
@@ -4041,9 +4041,9 @@ var ImageDialog = function(editorUi, title, initialValue, fn, ignoreExisting, co
 
 			    if (evt.dataTransfer.files.length > 0)
 			    {
-			    	editorUi.importFiles(evt.dataTransfer.files, 0, 0, editorUi.maxImageSize, function(data, mimeType, x, y, w, h)
+			    	editorUi.importFiles(evt.dataTransfer.files, 0, 0, editorUi.maxImageSize, function(data, mimeType, x, y, w, h, fileName, resize)
 			    	{
-			    		apply(data);
+			    		apply(data, resize);
 			    	}, function()
 			    	{
 			    		// No post processing

--- a/src/main/webapp/js/diagramly/EditorUi.js
+++ b/src/main/webapp/js/diagramly/EditorUi.js
@@ -6116,7 +6116,7 @@
 									    					{
 										    					var s = (!resizeImages || !this.isResampleImage(e.target.result, resampleThreshold)) ? 1 : Math.min(1, Math.min(maxSize / w2, maxSize / h2));
 											    				
-										    					return fn(data2, file.type, x + index * gs, y + index * gs, Math.round(w2 * s), Math.round(h2 * s), file.name);
+										    					return fn(data2, file.type, x + index * gs, y + index * gs, Math.round(w2 * s), Math.round(h2 * s), file.name, resizeImages);
 									    					}
 									    					else
 									    					{


### PR DESCRIPTION
There are a few issues with the ImageDialog. First, it does not listen to the confirmation about resizing the image. This change address that issue. importFiles should pass what the user answered to the resize dialog back into the insertImage inside ImageDialog.

Presently, ImageDialog forces the resize because it's passing a function into the argument resizeDialog of importFiles. That is then passed as the value of the force argument to confirmImageResize. This function looks to be code to handle multiple files. The next argument is also incorrect. It's supposed to be maxBytes, but it's being passed !mxEvent.isControlDown(evt). I'm not sure what the control button is supposed to do in this instance.

There are multiple locations that call importFiles that have this same incorrect pattern.

This change does not address the importing of multiple files. The imageDialog will not handle multiple files dropped at once. It will only insert the first image.

I suggest this code is just used as a diff to guide further fixes regarding the above issues.