### PR TITLE
Fix fill color for Bootstrap vertical buttons

### DIFF
--- a/src/main/webapp/js/diagramly/sidebar/Sidebar-Bootstrap.js
+++ b/src/main/webapp/js/diagramly/sidebar/Sidebar-Bootstrap.js
@@ -72,7 +72,7 @@
 			   	button4.geometry.offset = new mxPoint(0, -40);
 			   	button4.vertex = true;
 			   	bg.insert(button4);
-			   	var button1 = new mxCell('All Users', new mxGeometry(0, 0, 160, 40), inh + s + 'topButton;rSize=5;fillColor=#3D8BCD;strokeColor=#3D8BCD;fontColor=#ffffff;spacingLeft=10;align=left;whiteSpace=wrap;resizeWidth=1;');
+			   	var button1 = new mxCell('All Users', new mxGeometry(0, 0, 160, 40), s + 'topButton;rSize=5;fillColor=#3D8BCD;strokeColor=#3D8BCD;fontColor=#ffffff;spacingLeft=10;align=left;whiteSpace=wrap;resizeWidth=1;');
 			   	button1.geometry.relative = true;
 			   	button1.vertex = true;
 			   	bg.insert(button1);


### PR DESCRIPTION
You cannot change the color of the first button in the Bootstrap -> Vertical Button group. The fillColor was being set twice, so changing the fill would change the fill value that was being ignored.

Here is what the button was styled with

```
strokeColor=inherit;fillColor=inherit;gradientColor=inherit;html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.topButton;rSize=5;fillColor=#3D8BCD;strokeColor=#3D8BCD;fontColor=#ffffff;spacingLeft=10;align=left;whiteSpace=wrap;resizeWidth=1;
```
Then it was replacing the fillColor, which ended up replacing only the first one which has `inherit`
```
strokeColor=#b85450;fillColor=#f8cecc;html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.topButton;rSize=5;fillColor=#3D8BCD;strokeColor=#3D8BCD;fontColor=#ffffff;spacingLeft=10;align=left;whiteSpace=wrap;resizeWidth=1;
```

There was no need to inherit the color since it’s being explicitly set.