### PR TITLE
Change default extension from .xml to .dio

### DIFF
--- a/src/main/webapp/js/diagramly/Dialogs.js
+++ b/src/main/webapp/js/diagramly/Dialogs.js
@@ -2711,7 +2711,7 @@ var NewDialog = function(editorUi, compact, showName, callback, createOnly, canc
 				editorUi.mode == App.MODE_BROWSER) ? mxResources.get('diagramName') : mxResources.get('filename')) + ':');
 	}
 	
-	var ext = '.xml';
+	var ext = '.dio';
 	
 	if (editorUi.mode == App.MODE_GOOGLE && editorUi.drive != null)
 	{


### PR DESCRIPTION
The rational for this is loosely described in this issue/enhancement request for the desktop app:
[Allow association of specific file suffix on macOS and Window #35](https://github.com/jgraph/drawio-desktop/issues/35)

I feel this change provides several advantages that should be considered:

* .xml files can opened by a multitude of programs other than draw.io
  * users don't know which xml documents are for draw.io or something else.
  * draw.io cannot open xml files created by/for another program.
* draw.io xml files are not really using xml. They contain mostly serialized data stored in an xml structure: 
![snag_b1b505d](https://user-images.githubusercontent.com/4483057/44244588-b350f000-a1a2-11e8-8b31-805300dad957.png)
* .dio files work make it more clear to users that a specific app and potentially draw.io should be used.
  * if documented and endorsed on the draw.io website, users may be able to google "open .dio" file and know that draw.io or draw.io desktop should be used.
* Windows and macOS would be able to set draw.io desktop has the default application for .dio files:
  * ![snag_b2a56ae](https://user-images.githubusercontent.com/4483057/44245067-ff9d2f80-a1a4-11e8-9330-d58f7974f835.png)
  * better yet, the draw.io desktop installer could do this during setup
* Improved branding, users know .dio is for draw.io files and that association will build in the users minds over time like gdoc, gsheet, etc. represent Google's G Suite files.

Examples of companies doing this in the real world:
* Microsoft's Word, excel, and powerpoint's respective file formats are largely xml based, but they chose to use .docx, .xlsx, and .pptx to maintain the advantages described above. These applications are both online and desktop
* Figma is has a proprietary format, .fig, for exporting and sharing it's projects. This format can be opened or created using their web application or electron app.
* Google uses .gdoc, .gsheet, etc. for files synced to users computers using Google Drive

I can't think of many cons for users other than they will need to get used to the extension change.

Try it out here: https://kylestay.github.io/drawio/src/main/webapp/index.html

This page is able to create and open the .dio files just fine. When you associate the draw.io desktop application with them, you even get the draw.io logo displayed with each file as shown in the screenshot above. The desktop app already opens .dio files just fine.

Feel free to use a different extension, but please use something other than xml 😅

Thank you for such an awesome product!
- Kyle