### PR TITLE
Remove residual git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/main/webapp/mathjax"]
-	path = src/main/webapp/mathjax
-	url = https://github.com/jgraph/MathJax.git


### PR DESCRIPTION
The residual git submodule prevents `flatpak-builder` from checking out `drawio-desktop` somehow:

```
flatpak-builder build com.jgraph.drawio.desktop.yaml 
Downloading sources
Fetching git repo https://github.com/jgraph/drawio-desktop, ref refs/heads/master
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
Fetching git repo https://github.com/jgraph/drawio.git, ref refs/tags/v10.9.5
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 1 (delta 0), pack-reused 0
Unpacking objects: 100% (1/1), done.
Failed to download sources: module drawio-desktop: Not a gitlink tree: src/main/webapp/mathjax
```

Might as well delete it for good if not used at all.