### PR TITLE
Change Electron detection to be user agent based only

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -17,8 +17,8 @@
     <meta name="mobile-web-app-capable" content="yes">
 	<meta name="theme-color" content="#d89000">
 	<script type="text/javascript">
-		var mxIsElectron = (window && window.process && window.process.type) || (navigator.userAgent.toLowerCase().indexOf(' electron/') > -1);
-		var mxIsElectron5 = mxIsElectron && parseInt(process.versions.electron) >= 5;
+		var mxIsElectron = window && window.process && window.process.type;
+		var mxIsElectron5 = mxIsElectron && parseInt(window.process.versions.electron) >= 5;
 		var hostName = window.location.hostname;
 		// Supported domains are *.draw.io that draw.io host, or the packaged version in Quip
 		var supportedDomain = (hostName.substring(hostName.length - 8, hostName.length) === '.draw.io') ||


### PR DESCRIPTION
The Electron detection is currently base on the presence of `window.process` OR the user agent string.

This works fine for the `mxIsElectron`, but not for the Electron > 5 check as then we assume `window.process` is present. This is false for `webviews` and `iframes`. Draw.io is currently crashing if used inside an `iframe`, inside an Electron app.

This PR change the Electron check to be based solely on the user agent string.