### PR TITLE
EditorUi.drawHost customization

### DIFF
--- a/src/main/webapp/js/PreConfig.js
+++ b/src/main/webapp/js/PreConfig.js
@@ -7,3 +7,4 @@ window.EXPORT_URL = 'REPLACE_WITH_YOUR_IMAGE_SERVER';
 window.PLANT_URL = 'REPLACE_WITH_YOUR_PLANTUML_SERVER';
 window.DRAW_MATH_URL = 'math';
 window.DRAWIO_CONFIG = null; //Replace with your custom draw.io configurations. For more details, https://desk.draw.io/support/solutions/articles/16000058316
+window.EDITOR_UI_DRAW_URL = null; // Replace with your EditorUI server. default = 'https://www.draw.io'

--- a/src/main/webapp/js/diagramly/EditorUi.js
+++ b/src/main/webapp/js/diagramly/EditorUi.js
@@ -34,8 +34,8 @@
 	/**
 	 * Protocol and hostname to use for embedded files. Default is https://www.draw.io
 	 */
-	EditorUi.drawHost = 'https://www.draw.io';
-	
+	EditorUi.drawHost = window.EDITOR_UI_DRAW_URL;
+
 	/**
 	 * Switch to disable logging for mode and search terms.
 	 */
@@ -1528,11 +1528,13 @@
 			((redirect != null) ? '<meta http-equiv="refresh" content="0;URL=\'' + redirect + '\'"/>\n' : '') +
 			'<meta charset="utf-8"/>\n</head>\n<body>' +
 			'\n<div class="mxgraph" style="' + style + '" data-mxgraph="' + mxUtils.htmlEntities(JSON.stringify(data)) + '"></div>\n' +
-			((redirect == null) ? '<script type="text/javascript" src="' + js + '"></script>' :
-			'<a style="position:absolute;top:50%;left:50%;margin-top:-128px;margin-left:-64px;" ' +
-			'href="' + redirect + '" target="_blank"><img border="0" ' +
-			'src="' + EditorUi.drawHost + '/images/drawlogo128.png"/></a>') +
-			'\n</body>\n</html>\n';
+			((redirect == null) ?
+        '<script type="text/javascript" src="' + EditorUi.drawHost + '/js/PreConfig.js"></script>' +
+            '<script type="text/javascript" src="' + js + '"></script>' :
+			  '<a style="position:absolute;top:50%;left:50%;margin-top:-128px;margin-left:-64px;" ' +
+			    'href="' + redirect + '" target="_blank"><img border="0" ' +
+			    'src="' + EditorUi.drawHost + '/images/drawlogo128.png"/></a>') +
+			    '\n</body>\n</html>\n';
 	};
 
 	/**
@@ -5047,8 +5049,8 @@
 			(((urlParams['dev'] == '1') ?
 			'https://test.draw.io/js/viewer.min.js' :
 			window.VIEWER_URL ? window.VIEWER_URL : EditorUi.drawHost + '/js/viewer.min.js'));
-		var scr = '<script type="text/javascript" src="' + s2 + '"></script>';
-		
+		var scr = '<script type="text/javascript" src="/js/PreConfig.js"></script>' +
+              '<script type="text/javascript" src="' + s2 + '"></script>';
 		fn(value, scr);
 	};
 

--- a/src/main/webapp/js/diagramly/Init.js
+++ b/src/main/webapp/js/diagramly/Init.js
@@ -27,7 +27,7 @@ window.SAVE_URL = window.SAVE_URL || 'save';
 window.OPEN_URL = window.OPEN_URL || 'open';
 window.PROXY_URL = window.PROXY_URL || 'proxy';
 window.VIEWER_URL = null;
-window.EDITOR_UI_DRAW_URL = window.EDITOR_UI_DRAW_URL || 'http://editor-drawio.ido.test:8080';
+window.EDITOR_UI_DRAW_URL = window.EDITOR_UI_DRAW_URL || 'https://www.draw.io';
 
 // Paths and files
 window.SHAPES_PATH = window.SHAPES_PATH || 'shapes';

--- a/src/main/webapp/js/diagramly/Init.js
+++ b/src/main/webapp/js/diagramly/Init.js
@@ -27,6 +27,7 @@ window.SAVE_URL = window.SAVE_URL || 'save';
 window.OPEN_URL = window.OPEN_URL || 'open';
 window.PROXY_URL = window.PROXY_URL || 'proxy';
 window.VIEWER_URL = null;
+window.EDITOR_UI_DRAW_URL = window.EDITOR_UI_DRAW_URL || 'http://editor-drawio.ido.test:8080';
 
 // Paths and files
 window.SHAPES_PATH = window.SHAPES_PATH || 'shapes';


### PR DESCRIPTION
EditorUi.drawHost is now hard-coded as 'https://www.draw.io'. Rather, it would be better to customize it by  EDITOR_UI_DRAW_URL in PreConfig.js and also the default should be https://www.draw.io