### PR TITLE
Add presets for material design looking styles

### DIFF
--- a/src/main/webapp/js/diagramly/Editor.js
+++ b/src/main/webapp/js/diagramly/Editor.js
@@ -3603,7 +3603,8 @@
 
 			var stylenames = ['plain-gray', 'plain-blue', 'plain-green', 'plain-turquoise',
 				'plain-orange', 'plain-yellow', 'plain-red', 'plain-pink', 'plain-purple', 'gray',
-				'blue', 'green', 'turquoise', 'orange', 'yellow', 'red', 'pink', 'purple'];
+				'blue', 'green', 'turquoise', 'orange', 'yellow', 'red', 'pink', 'purple',
+				'material-blue', 'material-red', 'material-green', 'material-yellow', 'material-gray'];
 
 			function updateScheme(colorsets)
 			{

--- a/src/main/webapp/styles/default.xml
+++ b/src/main/webapp/styles/default.xml
@@ -116,6 +116,21 @@
 		<add as="fillColor" value="#E1D5E7"/>
 		<add as="strokeColor" value="#9673A6"/>
 	</add>
+	<add as="material-blue">
+		<add as="fillColor" value="#4285F4"/>
+	</add>
+	<add as="material-red">
+		<add as="fillColor" value="#DB4437"/>
+	</add>
+	<add as="material-green">
+		<add as="fillColor" value="#0F9D58"/>
+	</add>
+	<add as="material-yellow">
+		<add as="fillColor" value="#f4b400"/>
+	</add>
+	<add as="material-gray">
+		<add as="fillColor" value="#575757"/>
+	</add>
 	<add as="text">
 		<add as="fillColor" value="none"/>
 		<add as="gradientColor" value="none"/>


### PR DESCRIPTION
Creates 5 new styles which implement a material look. Material look is achieved by not setting any borders, shadows or other effects, only applying a solid fill color.
- Blue
- Red
- Green
- Yellow
- Gray

I don't know if a style can define to remove settings, if so the material styles should unset strokeColor, gradientColor and other properties that may have been added by other styles.

Untested, I don't have a testing setup.