### PR TITLE
Add "Paste and Match Style" feature for macOS

### DIFF
--- a/src/main/webapp/electron.js
+++ b/src/main/webapp/electron.js
@@ -652,6 +652,10 @@ app.on('ready', e =>
 	        label: 'Paste',
 	        accelerator: 'CmdOrCtrl+V',
 	        selector: 'paste:'
+	      }, {
+	        label: 'Paste and Match Style',
+	        accelerator: 'CmdOrCtrl+Alt+Shift+V',
+	        selector: 'pasteAndMatchStyle:'
 	      }]
 	    }]
 	    


### PR DESCRIPTION
This PR adds an ability to paste text ignoring the copied style on macOS for consistency with other macOS applications.
https://github.com/jgraph/drawio-desktop/issues/204