### PR TITLE
Ensure process is defined in version check

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -392,7 +392,7 @@
  * Main
  */
 if (navigator.userAgent != null && navigator.userAgent.toLowerCase().
-	indexOf(' electron/') >= 0 && process.versions.electron < 5)
+	indexOf(' electron/') >= 0 && typeof process !== 'undefined' && process.versions.electron < 5)
 {
 	// Redirects old Electron app to latest version
 	var div = document.getElementById('geInfo');


### PR DESCRIPTION
To allow for user agents which contain "electron" within their name but do not run within a node.js context, draw.io needs to check if the process object is defined at all before accessing its properties.

In particular, this is required to run diagrams.net within a Visual Studio Code webview extension which I am currently developing. For instance, on my machine, within a Visual Studio Code webview under MacOs, navigator.userAgent contains"Mozilla/5.0 (MacIntosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Code-Insiders/1.45.0-Insider Chrome/78.0.3904.130 Electron/7.2.2 Safari/537.36". Still, the process object is not defined.