### PR TITLE
Add context menu for text editing

### DIFF
--- a/src/main/webapp/electron.js
+++ b/src/main/webapp/electron.js
@@ -16,6 +16,7 @@ const {autoUpdater} = require("electron-updater")
 const Store = require('electron-store');
 const store = new Store();
 const ProgressBar = require('electron-progressbar');
+const contextMenu = require('electron-context-menu');
 const { systemPreferences } = require('electron')
 const disableUpdate = require('./disableUpdate').disableUpdate() || 
 						process.env.DRAWIO_DISABLE_UPDATE === 'true' || 
@@ -30,6 +31,10 @@ let windowsRegistry = []
 let cmdQPressed = false
 let firstWinLoaded = false
 let firstWinFilePath = null
+
+contextMenu({
+	showInspectElement: false
+});
 
 function createWindow (opt = {})
 {

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -24,12 +24,13 @@
   "homepage": "https://github.com/jgraph/drawio",
   "dependencies": {
     "commander": "^5.0.0",
+    "compression": "^1.7.4",
+    "crc": "^3.8.0",
+    "electron-context-menu": "^2.0.0",
     "electron-log": "^4.1.1",
-    "electron-updater": "^4.2.5",
     "electron-progressbar": "^1.2.0",
     "electron-store": "^5.1.0",
-    "compression": "^1.7.4",
-    "crc": "^3.8.0"
+    "electron-updater": "^4.2.5"
   },
   "devDependencies": {
     "electron": "^8.2.0"


### PR DESCRIPTION
This adds missing context menu in text editing.
As Electron does not have built-in context menu, the following package was used: https://github.com/sindresorhus/electron-context-menu

macOS example:
<img width="535" alt="Screen Shot 2020-04-30 at 21 50 30" src="https://user-images.githubusercontent.com/22008524/80751289-2bf00f80-8b32-11ea-90d2-763205fc4888.png">

Discussion:
https://github.com/jgraph/drawio-desktop/issues/204
