### PR TITLE
Fixed an issue where images with file sizes between 77KB and 100KB would be resized.

### DIFF
--- a/src/main/webapp/js/diagramly/EditorUi.js
+++ b/src/main/webapp/js/diagramly/EditorUi.js
@@ -7477,7 +7477,7 @@
 				{
 					if (text.substring(0, 5) == 'data:')
 					{
-						this.resizeImage(img, text, mxUtils.bind(this, function(data2, w2, h2)
+						this.resizeImage(img, text, text.length, mxUtils.bind(this, function(data2, w2, h2)
 	    				{
 							graph.setSelectionCell(graph.insertVertex(null, null, '', graph.snap(dx), graph.snap(dy),
 									w2, h2, 'shape=image;verticalLabelPosition=bottom;labelBackgroundColor=#ffffff;' +
@@ -8301,14 +8301,14 @@
 						    					{
 									    			this.loadImage(e.target.result, mxUtils.bind(this, function(img)
 									    			{
-									    				this.resizeImage(img, e.target.result, mxUtils.bind(this, function(data2, w2, h2)
+									    				this.resizeImage(img, e.target.result, file.size, mxUtils.bind(this, function(data2, w2, h2)
 									    				{
 										    				barrier(index, mxUtils.bind(this, function()
 												    		{
 										    					// Refuses to insert images above a certain size as they kill the app
 										    					if (data2 != null && data2.length < maxBytes)
 										    					{
-											    					var s = (!resizeImages || !this.isResampleImage(e.target.result, resampleThreshold)) ? 1 : Math.min(1, Math.min(maxSize / w2, maxSize / h2));
+											    					var s = (!resizeImages || !this.isResampleImage(file.size, resampleThreshold)) ? 1 : Math.min(1, Math.min(maxSize / w2, maxSize / h2));
 												    				
 											    					return fn(data2, file.type, x + index * gs, y + index * gs, Math.round(w2 * s), Math.round(h2 * s), file.name);
 										    					}
@@ -8472,23 +8472,23 @@
 	/**
 	 * 
 	 */
-	EditorUi.prototype.isResampleImage = function(data, thresh)
+	EditorUi.prototype.isResampleImage = function(size, thresh)
 	{
 		thresh = (thresh != null) ? thresh : this.resampleThreshold;
 
-		return data.length > thresh;
+		return size > thresh;
 	};
 	
 	/**
 	 * Resizes the given image if <maxImageBytes> is not null.
 	 */
-	EditorUi.prototype.resizeImage = function(img, data, fn, enabled, maxSize, thresh)
+	EditorUi.prototype.resizeImage = function(img, data, size, fn, enabled, maxSize, thresh)
 	{
 		maxSize = (maxSize != null) ? maxSize : this.maxImageSize;
 		var w = Math.max(1, img.width);
 		var h = Math.max(1, img.height);
 		
-		if (enabled && this.isResampleImage(data, thresh))
+		if (enabled && this.isResampleImage(size, thresh))
 		{
 			try
 			{


### PR DESCRIPTION
## Issue

### Overview

* This PR fixes an issue where images with file sizes ranging from 77KB to 100KB were being resized

### Prerequisite specifications

1. If the file size is larger than 100 KB, a confirmation message appears asking if you want to resize the image.
2. If the file size is less than 100KB, the confirmation dialog is not displayed and the image is imported as is. The image is imported without resizing.

### Detail

* There is a difference in the method of obtaining the file size between the decision to display the confirmation dialog for resizing at the time of image upload and the decision to actually resize the image.
* As a result, when an image is uploaded, it may be resized even though the confirmation dialog for resizing is not displayed when the image is uploaded.

* In order to display the resize confirmation dialog, the actual binary file size of the image is checked.
    * https://github.com/jgraph/drawio/blob/916290d3e8c9650f040ef76fb9da66fc9899ce16/src/main/webapp/js/diagramly/EditorUi.js#L8010
* On the other hand, in the process of determining whether or not to actually resize the image, the file size of the image after it has been base64 encoded is checked.
    * https://github.com/jgraph/drawio/blob/916290d3e8c9650f040ef76fb9da66fc9899ce16/src/main/webapp/js/diagramly/EditorUi.js#L8307

### Steps to reproduce

1. Drag and drop the following image onto the drawio canvas.
![test](https://user-images.githubusercontent.com/16251291/95132664-1b0b9000-079b-11eb-977d-01b56438f271.png)
2. The image is resized without showing the resize confirmation dialog.

### Before fix & After fix

* Before fix

![before_fix](https://user-images.githubusercontent.com/16251291/95133308-15627a00-079c-11eb-99cd-cff0803f5fbe.png)

* After fix

![after_fix](https://user-images.githubusercontent.com/16251291/95133289-0bd91200-079c-11eb-8f46-89d4a40e0e37.png)

## Solution

* I've also modified it to check the size of the original image data instead of the base64-encoded data when checking whether to actually resize it.