### PR TITLE
Swap c4Type `Container` and `Component`

### DIFF
--- a/src/main/webapp/js/diagramly/sidebar/Sidebar-C4.js
+++ b/src/main/webapp/js/diagramly/sidebar/Sidebar-C4.js
@@ -53,25 +53,10 @@
 			    
 			   	return sb.createVertexTemplateFromCells([bg], bg.geometry.width, bg.geometry.height, 'Software System');
 			}),				
-			this.addEntry(dt + 'component', function()
-		   	{
-			    var bg = new mxCell('', 
-			    		new mxGeometry(0, 0, w * 1.6, h * 1.1), 'rounded=1;whiteSpace=wrap;html=1;labelBackgroundColor=none;fillColor=#438DD5;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#3C7FC0;metaEdit=1;metaData={"c4Type":{"editable":false}};' + pts);
-		    	bg.vertex = true;
-		    	bg.setValue(mxUtils.createXmlDocument().createElement('object'));
-		    	bg.setAttribute('placeholders', '1');
-		        bg.setAttribute('c4Name', 'name');
-		        bg.setAttribute('c4Type', 'Component');
-		        bg.setAttribute('c4Technology', 'technology');
-		        bg.setAttribute('c4Description', 'Description');
-		    	bg.setAttribute('label', '<b>%c4Name%</b><div>[%c4Type%: %c4Technology%]</div><br><div>%c4Description%</div>');
-			    
-			   	return sb.createVertexTemplateFromCells([bg], bg.geometry.width, bg.geometry.height, 'Component');
-			}),				
 			this.addEntry(dt + 'container', function()
 		   	{
 			    var bg = new mxCell('', 
-			    		new mxGeometry(0, 0, w * 1.6, h * 1.1), 'rounded=1;whiteSpace=wrap;html=1;labelBackgroundColor=none;fillColor=#85BBF0;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#78A8D8;metaEdit=1;metaData={"c4Type":{"editable":false}};' + pts);
+			    		new mxGeometry(0, 0, w * 1.6, h * 1.1), 'rounded=1;whiteSpace=wrap;html=1;labelBackgroundColor=none;fillColor=#438DD5;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#3C7FC0;metaEdit=1;metaData={"c4Type":{"editable":false}};' + pts);
 		    	bg.vertex = true;
 		    	bg.setValue(mxUtils.createXmlDocument().createElement('object'));
 		    	bg.setAttribute('placeholders', '1');
@@ -82,6 +67,21 @@
 		    	bg.setAttribute('label', '<b>%c4Name%</b><div>[%c4Type%: %c4Technology%]</div><br><div>%c4Description%</div>');
 			    
 			   	return sb.createVertexTemplateFromCells([bg], bg.geometry.width, bg.geometry.height, 'Container');
+			}),				
+			this.addEntry(dt + 'component', function()
+		   	{
+			    var bg = new mxCell('', 
+			    		new mxGeometry(0, 0, w * 1.6, h * 1.1), 'rounded=1;whiteSpace=wrap;html=1;labelBackgroundColor=none;fillColor=#85BBF0;fontColor=#ffffff;align=center;arcSize=10;strokeColor=#78A8D8;metaEdit=1;metaData={"c4Type":{"editable":false}};' + pts);
+		    	bg.vertex = true;
+		    	bg.setValue(mxUtils.createXmlDocument().createElement('object'));
+		    	bg.setAttribute('placeholders', '1');
+		        bg.setAttribute('c4Name', 'name');
+		        bg.setAttribute('c4Type', 'Component');
+		        bg.setAttribute('c4Technology', 'technology');
+		        bg.setAttribute('c4Description', 'Description');
+		    	bg.setAttribute('label', '<b>%c4Name%</b><div>[%c4Type%: %c4Technology%]</div><br><div>%c4Description%</div>');
+			    
+			   	return sb.createVertexTemplateFromCells([bg], bg.geometry.width, bg.geometry.height, 'Component');
 			}),				
 			this.addEntry(dt + 'execution environment', function()
 		   	{


### PR DESCRIPTION
Container have higher hierarchy than Component. Container should have a darker blue shade, and Component have lighter blue. But currently, it's not. This commit fix issue https://github.com/jgraph/drawio/issues/1282

In order to avoid code conflict, the related changes in app.min.js is not committed.