### PR TITLE
#1079 - Unable to open svg with web version of draw.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 classes
 node_modules
 .vscode/settings.json
+.idea

--- a/src/main/webapp/js/diagramly/OneDriveClient.js
+++ b/src/main/webapp/js/diagramly/OneDriveClient.js
@@ -716,8 +716,8 @@ OneDriveClient.prototype.getFile = function(id, success, error, denyConvert, asL
 			    	}
 				}), ((meta.file != null && meta.file.mimeType != null &&
 						meta.file.mimeType.substring(0, 6) == 'image/' &&
-						meta.file.mimeType.substring(0, 9) != 'image/svg')) || /\.png$/i.test(meta.name) ||
-					/\.jpe?g$/i.test(meta.name) || /\.pdf$/i.test(meta.name));
+						meta.file.mimeType.substring(0, 9) != 'image/svg')) ||
+					binary || /\.jpe?g$/i.test(meta.name) || /\.pdf$/i.test(meta.name));
 			}
 		}
 		else

--- a/src/main/webapp/js/diagramly/OneDriveClient.js
+++ b/src/main/webapp/js/diagramly/OneDriveClient.js
@@ -714,9 +714,10 @@ OneDriveClient.prototype.getFile = function(id, success, error, denyConvert, asL
 			    	{
 			    		error(this.parseRequestText(req));
 			    	}
-				}), binary || (meta.file != null && meta.file.mimeType != null &&
-					(meta.file.mimeType.substring(0, 6) == 'image/' ||
-					meta.file.mimeType == 'application/pdf')));
+				}), ((meta.file != null && meta.file.mimeType != null &&
+						meta.file.mimeType.substring(0, 6) == 'image/' &&
+						meta.file.mimeType.substring(0, 9) != 'image/svg')) || /\.png$/i.test(meta.name) ||
+					/\.jpe?g$/i.test(meta.name) || /\.pdf$/i.test(meta.name));
 			}
 		}
 		else


### PR DESCRIPTION
Fixes #1079

Diagnose
---
The issue is a wrong check for binary content when downloading the file from OneDrive, and tries to read SVG-s as binary files.

Changes proposed
---
Adding an additional check for SVG types when calling the loadUrl method in the OneDriveClient#getFile function.