### PR TITLE
fix --page-index

### DIFF
--- a/src/main/webapp/electron.js
+++ b/src/main/webapp/electron.js
@@ -324,6 +324,7 @@ app.on('ready', e =>
 	    	if (options.pageIndex != null && options.pageIndex >= 0)
 			{
 	    		from = options.pageIndex;
+			to = from;
 			}
 	    	else if (options.pageRage && options.pageRage.length == 2)
 			{


### PR DESCRIPTION
The option --page-index exports all pages from defined page-index up to the last page. According to --help it should export one page only.