### PR TITLE
Fix incorrect application icon behavior on Linux

### DIFF
--- a/src/main/webapp/electron.js
+++ b/src/main/webapp/electron.js
@@ -81,6 +81,7 @@ function createWindow (opt = {})
 		backgroundColor: '#FFF',
 		width: 1600,
 		height: 1200,
+		icon: `${__dirname}/images/drawlogo256.png`,
 		webViewTag: false,
 		'web-security': true,
 		webPreferences: {


### PR DESCRIPTION
Fixes jgraph/drawio-desktop#547. I have tested this change only on Linux+KDE and can confirm it works. Obviously some testing on Mac and Windows would be nice to confirm it doesn't break anything. More details in the linked issue.

Before:

https://user-images.githubusercontent.com/840021/149759445-c634f900-6231-47df-a629-bbfb343af455.mp4

After:

https://user-images.githubusercontent.com/840021/149759462-2e23400a-b4e3-447f-92a6-c18aae09564b.mp4


