### PR TITLE
Fix loading order for javax.cache.CacheManager on App Engine

### DIFF
--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -20,6 +20,11 @@
 	</include>
   </static-files>
 
+  <!-- App engine has conflicting interfaces for javax.cache.CacheManager -->
+  <class-loader-config>
+    <priority-specifier filename="cache-api-1.1.1.jar"/>
+  </class-loader-config>
+
   <instance-class>F1</instance-class>
   <automatic-scaling>
     <max-idle-instances>1</max-idle-instances>


### PR DESCRIPTION
I was running an drawio fork on app engine and Google Drive integration suddenly started failing with IncompatibleClassChangeError errors. Found https://stackoverflow.com/q/46582783 which fixed it.

This is mostly a heads up if anyone else runs into similar issues, feel free to re-investigate. I'm also not sure if this is easily reproducible on the public App Engine. Following up with GAE to see if this is a bigger issue.