### PR TITLE
Update Sidebar-C4.js

### DIFF
--- a/src/main/webapp/js/diagramly/sidebar/Sidebar-C4.js
+++ b/src/main/webapp/js/diagramly/sidebar/Sidebar-C4.js
@@ -90,7 +90,7 @@
 		    	bg.setValue(mxUtils.createXmlDocument().createElement('object'));
 		    	bg.setAttribute('placeholders', '1');
 		        bg.setAttribute('c4Type', 'Container name');
-		        bg.setAttribute('c4Container', 'Container ');
+		        bg.setAttribute('c4Container', 'Container');
 		        bg.setAttribute('c4Technology', 'e.g. Oracle Database 12');
 		        bg.setAttribute('c4Description', 'Description of storage type container role/responsibility.');
 		    	bg.setAttribute('label', '<font style="font-size: 16px"><b>%c4Type%</font><div>[%c4Container%:&nbsp;%c4Technology%]</div><br><div><font style="font-size: 11px"><font color="#E6E6E6">%c4Description%</font></div>');


### PR DESCRIPTION
Removes superfluous white space:

# Original
White space seen before the colon after the text e.g. "[Container : ...]"
![image](https://user-images.githubusercontent.com/113126667/193555733-8db33a59-4d2e-4e12-8db7-18cbbd50a2e0.png)

# Altered
White space removed seen before the colon after the text e.g. "[Container: ...]"
![image](https://user-images.githubusercontent.com/113126667/193555817-3332b69b-fb71-42fd-bfbb-63bd0059eb64.png)
