### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,3 +11,9 @@
 
 Email support@diagrams.net. If you do not wish to submit by email, please 
 ask for an alternative via email or Github issue.
+
+# Reporting a Vulnerability
+
+If you discover a security vulnerability in drawio please disclose it via [our huntr page](https://huntr.dev/repos/jgraph/drawio/). Information about bounties, CVEs, response times and past reports are all there..
+
+Thank you for improving the security of drawio.


### PR DESCRIPTION
As requested through the platform by @davidjgraph, this will point your security policy to [huntr.dev](https://huntr.dev/repos/jgraph/drawio})