### PR TITLE
Fix 26.6.1 version in ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-04-JUL-2023: 21.6.0
+04-JUL-2023: 21.6.1
 
 - Fixes special cases in replace shape [drawio-3686]
 - Enables new dark mode in production [drawio-3701]


### PR DESCRIPTION
Some typo has been done in the latest ChangeLog release.