### PR TITLE
Consider pathname when building edit link

### DIFF
--- a/src/main/webapp/js/grapheditor/Editor.js
+++ b/src/main/webapp/js/grapheditor/Editor.js
@@ -549,7 +549,7 @@ Editor.prototype.appName = document.title;
 /**
  * 
  */
-Editor.prototype.editBlankUrl = window.location.protocol + '//' + window.location.host + '/';
+Editor.prototype.editBlankUrl = window.location.protocol + '//' + window.location.host + '/' + window.location.pathname; 
 
 /**
  * Default value for the graph container overflow style.


### PR DESCRIPTION
The current logic fails when Draw.io is hosted at a subpath.

Here is a slightly anonymized example:

We host Draw.io at https://our-domain.com/tools/diagrams/:

<img width="1339" alt="image" src="https://github.com/jgraph/drawio/assets/1540469/21dd9510-bf5d-487c-a688-e1389e30371c">

The Edit link opens https://our-domain.com/?client=1, while it should actually open https://our-domain.com/tools/diagrams/?client=1:

![image](https://github.com/jgraph/drawio/assets/1540469/8889eb0e-a4c5-447f-9678-fe2f05852150)

This PR fixes the construction of the edit URL so that it works for all cases.
