### PR TITLE
Ignore 404 errors in GitLab group iteration

### DIFF
--- a/src/main/webapp/js/diagramly/GitLabClient.js
+++ b/src/main/webapp/js/diagramly/GitLabClient.js
@@ -1240,10 +1240,10 @@ GitLabClient.prototype.showGitLabDialog = function(showFiles, fn, hideNoFilesErr
 			{
 				this.ui.tryAndHandle(mxUtils.bind(this, function()
 				{
-					callback(group, JSON.parse(req.getText()));
+					callback(group, JSON.parse(req.getText() || '[]'));
 					spinnerRequestFinished();
 				}));
-			}), error);
+			}), error, true);
 		});
 		
 		listGroups(mxUtils.bind(this, function(groups)


### PR DESCRIPTION
When making requests to the GitLab API, a 404 error can be returned in two scenarios: when attempting to access a resource for which the user lacks permissions, or when querying a resource that does not exist (or has just been deleted).

In the case of missing permissions, GitLab intentionally returns a 404 status code instead of the more conventional 403 to avoid revealing the existence of restricted resources.

To address this issue, this pull request proposes a solution to specifically handle 404 errors occurring on calls made to the /groups/xxx/projects endpoint. If a 404 error is encountered while attempting to list projects within a group, it suggests either a permissions issue or that the group does not contain any projects. In either scenario, it's optimal to manage this situation by proceeding with the iteration through other groups and providing the user with a consolidated list of projects that could be successfully retrieved. Rather than triggering a "**404 Group Not Found**" error : 
![image](https://github.com/jgraph/drawio/assets/96389640/25e66b7b-2f0a-4549-ab78-149ef7a63a8f)

The current approach, treating 404 errors as "true" errors and triggering retries via the error callback, leads to unnecessary retries and ultimately does not provide meaningful results.

By treating 404 errors on the /groups/xxx/projects endpoint as expected behavior and handling them accordingly, we can improve the robustness and efficiency of our API requests.