### PR TITLE
Renaming a file stored in browser encounters "Not a diagram file" error

### DIFF
--- a/src/main/webapp/js/diagramly/StorageFile.js
+++ b/src/main/webapp/js/diagramly/StorageFile.js
@@ -481,8 +481,6 @@ StorageFile.prototype.rename = function(title, success, error)
 		{
 			var fn = mxUtils.bind(this, function()
 			{
-				this.title = title;
-				
 				// Updates the data if the extension has changed
 				if (!this.hasSameExtension(oldTitle, title))
 				{
@@ -491,7 +489,8 @@ StorageFile.prototype.rename = function(title, success, error)
 				
 				this.saveFile(title, false, mxUtils.bind(this, function()
 				{
-					this.ui.removeLocalData(oldTitle, success);
+					// This section requires the use of deleteFile to delete old data from the database.
+					StorageFile.deleteFile(this.ui, oldTitle, success, error);
 				}), error);
 			});
 			


### PR DESCRIPTION
When user data is stored in the browser, attempting to rename the file results in a "Not a diagram file" error. The detailed reproduction steps are as follows:

1、Save a file to the browser.
2、Click on the file name to attempt to rename it.
<img width="1167" alt="image" src="https://github.com/user-attachments/assets/6932abd9-918c-4b38-9a3e-d8f260054ff6">

Let me know if you need any clarification or have additional details to include in the PR description.