### PR TITLE
Fix: Support animations for multiple pages

### DIFF
--- a/src/main/webapp/plugins/animation.js
+++ b/src/main/webapp/plugins/animation.js
@@ -296,6 +296,7 @@ Draw.loadPlugin(function(editorUi)
 		
 		var applyBtn = mxUtils.button('Apply', function()
 		{
+            var root = editorUi.editor.graph.getModel().getRoot()
 			editorUi.editor.graph.setAttributeForCell(root, 'animation', list.value);
 		});
 		td21.appendChild(applyBtn);
@@ -313,6 +314,17 @@ Draw.loadPlugin(function(editorUi)
 		this.window.setResizable(true);
 		this.window.setClosable(true);
 		this.window.setVisible(true);
+
+        var currentRoot = editorUi.editor.graph.getModel().getRoot()
+        editorUi.editor.addListener('pageSelected', () => {
+            editorUi.editor.graph.setAttributeForCell(currentRoot, 'animation', list.value)
+            setTimeout(() => {
+                currentRoot = editorUi.editor.graph.getModel().getRoot()
+                if (currentRoot.value != null && typeof (currentRoot.value) == 'object') {
+                    list.value = currentRoot.value.getAttribute('animation')
+                }
+            }, 1)
+        })
 	};
 	
 	// Autostart in chromeless mode


### PR DESCRIPTION
**Current behaviour:** 
If a diagram has multiple pages, the animation plugin only applies the animation for Page 1. Additionally, changing pages does not change or show the correct animation for the current page.

**What this fix does:**

1. Correctly applies animations to the current page.
2. Switches animations based on which page you are on
3. Auto-applies animations when changing pages.


Screen capture of behaviour after applying this fix:
https://github.com/user-attachments/assets/0b55fe54-2240-4468-ae0c-6bec4534fe71

