### PR TITLE
Fix UTF-8 Base64 decoding corruption in GitHub files

### DIFF
--- a/src/main/webapp/js/diagramly/GitHubClient.js
+++ b/src/main/webapp/js/diagramly/GitHubClient.js
@@ -606,7 +606,14 @@ GitHubClient.prototype.createGitHubFile = function(org, repo, ref, data, asLibra
 			}
 			else
 			{
-				content = Base64.decode(content);
+				try{
+					// Properly decode UTF-8 content from base64 to handle emoji and international characters
+					const bytes = Uint8Array.from(Base64.decode(content, true), ch => ch.charCodeAt(0));	
+					content = new TextDecoder('utf-8').decode(bytes);
+				}
+				catch(e){
+					content = Base64.decode(content);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Fix Description
Fixes issue - #5255
Resolves UTF-8 character corruption in GitHub file loading by replacing naive Base64 decoding with UTF-8 aware decoding.

## Testing
- Verified fix using browser console testing.
- Characters like 👨‍💻 now load correctly instead of showing corruption - ������.
- Includes fallback for compatibility

## Code Review Checklist
- ✅ Implements intended functionality (UTF-8 fix)
- ✅ Handles error scenarios (try-catch with fallback)
- ✅ Follows existing code patterns
- ✅ No performance impact (minimal overhead)
- ✅ Maintains backward compatibility