### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -24,7 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
       - name: Setup Pages
         uses: actions/configure-pages@v4
         

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v4
-        
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: './src/main/webapp'
-          
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './src/main/webapp'
+          
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you are using a draw.io project/product and have issues or questions about th
 Running
 -------
 
-One way to run draw.io is to fork this project, [publish the master branch to GitHub pages](https://help.github.com/categories/github-pages-basics/) and the [pages sites](https://jgraph.github.io/drawio/src/main/webapp/index.html) will have the full editor functionality (sans the integrations).
+One way to run draw.io is to fork this project, [publish the master branch to GitHub pages](https://help.github.com/categories/github-pages-basics/) and the [pages sites](https://bmfoste.github.io/drawio/src/main/webapp/index.html) will have the full editor functionality (sans the integrations).
 
 Another way is to use [the recommended Docker project](https://github.com/jgraph/docker-drawio) or to download [draw.io Desktop](https://get.diagrams.net).
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you are using a draw.io project/product and have issues or questions about th
 Running
 -------
 
-One way to run draw.io is to fork this project, [publish the master branch to GitHub pages](https://help.github.com/categories/github-pages-basics/) and the [pages sites](https://bmfoste.github.io/drawio/src/main/webapp/index.html) will have the full editor functionality (sans the integrations).
+One way to run draw.io is to fork this project, [publish the main branch to GitHub pages](https://help.github.com/categories/github-pages-basics/) and the [pages sites](https://bmfoste.github.io/drawio/src/main/webapp/index.html) will have the full editor functionality (sans the integrations).
 
 Another way is to use [the recommended Docker project](https://github.com/jgraph/docker-drawio) or to download [draw.io Desktop](https://get.diagrams.net).
 


### PR DESCRIPTION
Introduces a GitHub Actions workflow to deploy the project to GitHub Pages from the main branch. Updates the README to reference the correct GitHub Pages URL for this repository.