### PR TITLE
Add var at state = graph.getView().getState(cells[i]);

### DIFF
--- a/src/main/webapp/js/grapheditor/Actions.js
+++ b/src/main/webapp/js/grapheditor/Actions.js
@@ -884,7 +884,7 @@ Actions.prototype.init = function()
 			
 			for (var i = 0; i < cells.length; i++)
 			{
-				state = graph.getView().getState(cells[i]);
+				var state = graph.getView().getState(cells[i]);
 				
 				if (state != null)
 				{


### PR DESCRIPTION
I'm not quite sure about this fix (it was not tested and I'm not an expert for drawio, so maybe this was intentional, but it looks like a missing "var" to me, but please correct me if I'm mistaken)