### PR TITLE
Allows long words to be broken and wrap onto the next line

### DIFF
--- a/src/main/webapp/mxgraph/src/util/mxConstants.js
+++ b/src/main/webapp/mxgraph/src/util/mxConstants.js
@@ -575,11 +575,10 @@
 	/**
 	 * Variable: WORD_WRAP
 	 * 
-	 * Defines the CSS value for the word-wrap property. Default is "normal".
-	 * Change this to "break-word" to allow long words to be able to be broken
-	 * and wrap onto the next line.
+	 * Defines the CSS value for the word-wrap property. Default is "break-word"
+	 * to allow long words to be broken and wrap onto the next line.
 	 */
-	WORD_WRAP: 'normal',
+	WORD_WRAP: 'break-word',
 
 	/**
 	 * Variable: ABSOLUTE_LINE_HEIGHT


### PR DESCRIPTION
# Pull request overview
This pull request modifies the default word-wrap property value in the drawio repository to allow long words to be broken and wrapped onto the next line. This is a necessary feature, as many third-party drawing tools enable this functionality by default. I believe drawio should also enable it by default!

**Key Changes:**
- Change the default value of the 'word-wrap' property to 'break-word'.

**Effect as shown below:**
<img width="293" height="193" alt="2026-02-13_114729_279" src="https://github.com/user-attachments/assets/89d3b0fa-0588-4791-b497-b31f344d5681" />
